### PR TITLE
Two or more views of the same type get skipped

### DIFF
--- a/Sources/Infinite Grid/GridObjectP.swift
+++ b/Sources/Infinite Grid/GridObjectP.swift
@@ -29,19 +29,9 @@
 import SwiftUI
 
 /// A generic protocol for creating objects to be plotted on a grid
-public protocol GridObject: Identifiable {
+public protocol GridObject {
     /// Position of the grid object.
     var pos: CGPoint { get set }
     // The view to display on screen
     var content: any View { get }
-}
-
-/// An extension to the GridObject protocol allowing for the use of a unique identifier.
-public extension GridObject {
-    /// The stable identity of the entity associated with this instance.
-    var id: String {
-        get {
-            return Mirror(reflecting: content).description
-        }
-    }
 }

--- a/Sources/Infinite Grid/InfiniteGrid.swift
+++ b/Sources/Infinite Grid/InfiniteGrid.swift
@@ -170,7 +170,7 @@ public struct InfiniteGrid: View {
                 context.stroke(controller.drawGrid(), with: gridShading, lineWidth: lineThickness)
             }
             .gesture(gridDrag)
-            ForEach(views, id: \.id) { gridObject in // Views to show on grid
+            ForEach(Array(zip(views.indices, views)), id: \.0) { _, gridObject in // Views to show on grid
                 AnyView(gridObject.content)
                     .fixedSize()
                     .position(


### PR DESCRIPTION
When providing more than one of the same kind of view, all subsequent views of that type previously were skipped due to these views sharing the same id.

The new implementation uses the index within the array, thus the GridObject protocol no longer needs to conform to Identifiable.